### PR TITLE
Fix issue when arg_separator.output redefined for local usage

### DIFF
--- a/src/Helpers/B2BFamily.php
+++ b/src/Helpers/B2BFamily.php
@@ -175,7 +175,7 @@ class B2BFamily
         $endpoint = 'https://api.b2bfamily.com' . $url;
 
         if (in_array($method, [self::METHOD_GET, self::METHOD_DELETE])) {
-            $endpoint .= '?' . http_build_query($parameters);
+            $endpoint .= '?' . http_build_query($parameters, null, '&');
         }
 
         $ch = curl_init();

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -144,12 +144,12 @@ class Request
             $query = http_build_query(array_merge($this->parameters->getGet(), [
                 'USER_LOGIN' => $this->parameters->getAuth('login'),
                 'USER_HASH' => $this->parameters->getAuth('apikey'),
-            ]));
+            ]), null, '&');
         } else {
             $query = http_build_query(array_merge($this->parameters->getGet(), [
                 'login' => $this->parameters->getAuth('login'),
                 'api_key' => $this->parameters->getAuth('apikey'),
-            ]));
+            ]), null, '&');
         }
 
         return sprintf('https://%s%s?%s', $this->parameters->getAuth('domain'), $url, $query);


### PR DESCRIPTION
When you have redefined global arg_separator.output in your config for local url generation you get error with unauthorized request to AmoCRM. So lib does not work in my PHP configuration (I'm using ; as separator) and thats why it's trying to build query with ; as separator by default.
The proposal is to use & default separator as argument in http_build_query to fix that issue.