### PR TITLE
Request: Use HTTP response code in case of invalid response body

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -253,18 +253,23 @@ class Request
     {
         $result = json_decode($response, true);
 
-        if (!isset($result['response'])) {
-            return false;
-        } elseif (floor($info['http_code'] / 100) >= 3) {
-            $code = 0;
+        if (floor($info['http_code'] / 100) >= 3) {
             if (isset($result['response']['error_code']) && $result['response']['error_code'] > 0) {
                 $code = $result['response']['error_code'];
-            }
-            if ($this->v1 === false) {
-                throw new Exception($result['response']['error'], $code);
+            } elseif ($result !== null) {
+                $code = 0;
             } else {
-                throw new Exception(json_encode($result['response']));
+                $code = $info['http_code'];
             }
+            if ($this->v1 === false && isset($result['response']['error'])) {
+                throw new Exception($result['response']['error'], $code);
+            } elseif (isset($result['response'])) {
+                throw new Exception(json_encode($result['response']));
+            } else {
+                throw new Exception('Invalid response body.', $code);
+            }
+        } elseif (!isset($result['response'])) {
+            return false;
         }
 
         return $result['response'];

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -223,6 +223,21 @@ class RequestTest extends TestCase
         $this->invokeMethod($this->request, 'parseResponse', [$response, $info]);
     }
 
+    /**
+     * @expectedException \AmoCRM\Exception
+     * @expectedExceptionCode 502
+     * @expectedExceptionMessage Invalid response body.
+     */
+    public function testParseInvalidResponseWithHttpError502()
+    {
+        $response = '<html>Bad Gateway</html>';
+        $info = [
+            'http_code' => 502,
+        ];
+
+        $this->invokeMethod($this->request, 'parseResponse', [$response, $info]);
+    }
+
     public function testPrintDebug()
     {
         $this->request->debug(true);

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -208,6 +208,21 @@ class RequestTest extends TestCase
         $this->invokeMethod($this->request, 'parseResponse', [$response, $info]);
     }
 
+    /**
+     * @expectedException \AmoCRM\Exception
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage Аккаунт заблокирован, за неоднократное превышение количества запросов в секунду
+     */
+    public function testParseInvalidResponseWithHttpError()
+    {
+        $response = '~~GO AWAY~~';
+        $info = [
+            'http_code' => 403,
+        ];
+
+        $this->invokeMethod($this->request, 'parseResponse', [$response, $info]);
+    }
+
     public function testPrintDebug()
     {
         $this->request->debug(true);


### PR DESCRIPTION
Sometimes AmoCRM goes crazy and returns JSON wrapped into HTML. Here is an example:
```http
HTTP/1.1 403 Forbidden
Server: nginx
Date: Thu, 08 Jun 2017 15:54:31 GMT
Content-Type: text/html
Content-Length: 300
Connection: keep-alive
ETag: "59394a65-12c"

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
    <meta http-equiv="Content-Type" content="application/json; charset=utf-8">
    <title>amoCRM: Forbidden (403)</title>
</head>
<body>
    {"response":{"error":"403 Forbidden"}}
</body>
</html>
```

For now, parser silently returns `false` for this kind of response. No exceptions thrown.

I fixed parser to use HTTP response code in case of invalid (`null`) response bodies and to throw an `\AmoCRM\Exception`.