### PR TITLE
Update Lead.php

### DIFF
--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -161,7 +161,10 @@ class Lead extends AbstractModel
         $parameters['leads']['update'][] = $lead;
 
         $response = $this->postRequest('/private/api/v2/json/leads/set', $parameters);
+        if (isset($response['leads']['update']['errors'][$id])) {
+            throw new Exception($response['leads']['update']['errors'][$id]);
+        }
 
-        return isset($response['leads']) ? true : false;
+        return isset($response['leads']['update']['id']) ? true : false;
     }
 }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -167,6 +167,6 @@ class Lead extends AbstractModel
             throw new Exception($response['leads']['update']['errors'][$id]);
         }
 
-        return isset($response['leads']['update'][0]['id']) ? true : false;
+        return empty($response['leads']['update']['errors']);
     }
 }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -2,8 +2,6 @@
 
 namespace AmoCRM\Models;
 
-use AmoCRM\Exception;
-
 /**
  * Class Lead
  *
@@ -144,7 +142,7 @@ class Lead extends AbstractModel
      * @param int $id Уникальный идентификатор сделки
      * @param string $modified Дата последнего изменения данной сущности
      * @return bool Флаг успешности выполнения запроса
-     * @throws Exception
+     * @throws \AmoCRM\Exception
      */
     public function apiUpdate($id, $modified = 'now')
     {
@@ -163,9 +161,6 @@ class Lead extends AbstractModel
         $parameters['leads']['update'][] = $lead;
 
         $response = $this->postRequest('/private/api/v2/json/leads/set', $parameters);
-        if (isset($response['leads']['update']['errors'][$id])) {
-            throw new Exception($response['leads']['update']['errors'][$id]);
-        }
 
         return empty($response['leads']['update']['errors']);
     }

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
+
 /**
  * Class Lead
  *
@@ -142,7 +144,7 @@ class Lead extends AbstractModel
      * @param int $id Уникальный идентификатор сделки
      * @param string $modified Дата последнего изменения данной сущности
      * @return bool Флаг успешности выполнения запроса
-     * @throws \AmoCRM\Exception
+     * @throws Exception
      */
     public function apiUpdate($id, $modified = 'now')
     {
@@ -165,6 +167,6 @@ class Lead extends AbstractModel
             throw new Exception($response['leads']['update']['errors'][$id]);
         }
 
-        return isset($response['leads']['update']['id']) ? true : false;
+        return isset($response['leads']['update'][0]['id']) ? true : false;
     }
 }


### PR DESCRIPTION
Если изменяешь новосозданный lead, практически постоянно получаешь json_encode($response) = {"leads":{"update":{"errors":{"15907769":"Last modified date is older than in database"}}},"server_time":1500032678}
При такой ошибке метод отвечает что изменения произошли, однако по факту изменений не было