### PR TITLE
Added batch delete catalog elements

### DIFF
--- a/src/Models/CatalogElement.php
+++ b/src/Models/CatalogElement.php
@@ -143,4 +143,35 @@ class CatalogElement extends AbstractModel
 
         return empty($response['catalog_elements']['delete']['errors']);
     }
+
+    /**
+     * Удаление элементов каталога
+     *
+     * Метод позволяет удалять данные по уже существующим элементам каталога
+     *
+     * @link https://developers.amocrm.com/rest_api/catalog_elements/set.php
+     * @param array $ids Уникальные идентификаторы элементов каталога
+     * @return bool Флаг успешности выполнения запроса
+     * @throws \AmoCRM\Exception
+     */
+    public function apiDeleteBatch(array $ids)
+    {
+        array_walk($ids, function($id){
+            $this->checkId($id);
+        });
+
+        $parameters = [
+            'catalog_elements' => [
+                'delete' => $ids,
+            ],
+        ];
+
+        $response = $this->postRequest('/private/api/v2/json/catalog_elements/set', $parameters);
+
+        if (!isset($response['catalog_elements']['delete']['errors'])) {
+            return false;
+        }
+
+        return empty($response['catalog_elements']['delete']['errors']);
+    }
 }

--- a/tests/Models/CatalogElementTest.php
+++ b/tests/Models/CatalogElementTest.php
@@ -139,6 +139,13 @@ class CatalogElementTest extends TestCase
         $this->assertEquals([1], $this->model->mockParameters['catalog_elements']['delete']);
     }
 
+    public function testApiDeleteBatch()
+    {
+        $this->assertTrue($this->model->apiDeleteBatch([1,2,3]));
+        $this->assertEquals('/private/api/v2/json/catalog_elements/set', $this->model->mockUrl);
+        $this->assertEquals([1,2,3], $this->model->mockParameters['catalog_elements']['delete']);
+    }
+
     public function fieldsProvider()
     {
         return [


### PR DESCRIPTION
Метод для пакетного удаление элементов каталога. 
`
// Массив элементов каталога для удаление
$catalogElementsId = [12,13,14,15];

$amo->catalog_element->apiDeleteBatch($catalogElementsId);`