### PR TITLE
Reuse cURL handle to keep connection alive

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace AmoCRM;
 
 use AmoCRM\Models\ModelInterface;
+use AmoCRM\Request\CurlHandle;
 use AmoCRM\Request\ParamsBag;
 use AmoCRM\Helpers\Fields;
 
@@ -50,6 +51,11 @@ class Client
     public $parameters = null;
 
     /**
+     * @var CurlHandle Экземпляр CurlHandle для повторного использования
+     */
+    private $curlHandle;
+
+    /**
      * Client constructor
      *
      * @param string $domain Поддомен или домен amoCRM
@@ -74,6 +80,8 @@ class Client
         }
 
         $this->fields = new Fields();
+
+        $this->curlHandle = new CurlHandle();
     }
 
     /**
@@ -94,7 +102,7 @@ class Client
         // Чистим GET и POST от предыдущих вызовов
         $this->parameters->clearGet()->clearPost();
 
-        return new $classname($this->parameters);
+        return new $classname($this->parameters, $this->curlHandle);
     }
 
     /**

--- a/src/Request/CurlHandle.php
+++ b/src/Request/CurlHandle.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace AmoCRM\Request;
+
+use AmoCRM\NetworkException;
+
+/**
+ * Class CurlHandle
+ *
+ * Класс, хранящий повторно используемый обработчик cURL
+ *
+ * @package AmoCRM\Request
+ * @author dotzero <mail@dotzero.ru>
+ * @link http://www.dotzero.ru/
+ * @link https://github.com/dotzero/amocrm-php
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class CurlHandle
+{
+    /**
+     * @var resource Повторно используемый обработчик cURL
+     */
+    private $handle;
+
+    /**
+     * CurlHandle destructor.
+     */
+    public function __destruct()
+    {
+        if ($this->handle !== null) {
+            @curl_close($this->handle);
+        }
+    }
+
+    /**
+     * Open cURL handle.
+     *
+     * @throws NetworkException
+     *
+     * @return resource
+     */
+    public function open()
+    {
+        if ($this->handle !== null) {
+            return $this->handle;
+        }
+
+        if (!function_exists('curl_init')) {
+            throw new NetworkException('The cURL PHP extension was not loaded.');
+        }
+        $this->handle = curl_init();
+
+        return $this->handle;
+    }
+
+    /**
+     * Close cURL handle.
+     */
+    public function close()
+    {
+        if ($this->handle === null) {
+            return;
+        }
+
+        curl_setopt($this->handle, CURLOPT_HEADERFUNCTION, null);
+        curl_setopt($this->handle, CURLOPT_READFUNCTION, null);
+        curl_setopt($this->handle, CURLOPT_WRITEFUNCTION, null);
+        curl_setopt($this->handle, CURLOPT_PROGRESSFUNCTION, null);
+        curl_reset($this->handle);
+    }
+}

--- a/tests/Request/CurlHandleTest.php
+++ b/tests/Request/CurlHandleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+class CurlHandleTest extends TestCase
+{
+    /** @var \AmoCRM\Request\CurlHandle */
+    private $handle;
+
+    public function setUp()
+    {
+        $this->handle = new \AmoCRM\Request\CurlHandle();
+    }
+
+    public function testOpen()
+    {
+        $ch = $this->handle->open();
+        $this->assertInternalType('resource', $ch);
+    }
+
+    public function testOpenWillReturnTheSameHandle()
+    {
+        $ch1 = $this->handle->open();
+        $this->handle->close();
+        $ch2 = $this->handle->open();
+        $this->assertEquals($ch1, $ch2);
+    }
+
+    public function testClose()
+    {
+        $ch = $this->handle->open();
+        $this->handle->close();
+    }
+
+    public function testCloseWithoutOpen()
+    {
+        $this->handle->close();
+    }
+}

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -90,15 +90,15 @@ class RequestTest extends TestCase
 
         $actual = $this->invokeMethod($this->request, 'prepareHeaders');
 
-        $this->assertCount(1, $actual);
+        $this->assertCount(2, $actual);
         $this->assertContains('Content-Type: application/json', $actual);
 
         $actual = $this->invokeMethod($this->request, 'prepareHeaders', [$dt]);
-        $this->assertCount(2, $actual);
+        $this->assertCount(3, $actual);
         $this->assertContains('IF-MODIFIED-SINCE: Mon, 02 Jan 2017 12:30:00 +0000', $actual);
 
         $actual = $this->invokeMethod($this->request, 'prepareHeaders', [$ts]);
-        $this->assertCount(2, $actual);
+        $this->assertCount(3, $actual);
         $this->assertContains('IF-MODIFIED-SINCE: 1483360200', $actual);
     }
 


### PR DESCRIPTION
Test script:
```php
<?php
require 'vendor/autoload.php';

$amo = new \AmoCRM\Client(DOMAIN, USERNAME, PASSWORD);
for ($i = 0; $i < 10; $i++) {
    $amo->account->apiCurrent();
}
```
Before:
```
$ time php testReuse.php

real    0m4.316s
user    0m0.340s
sys     0m0.057s
```
After:
```
$ time php testReuse.php

real    0m2.567s
user    0m0.205s
sys     0m0.036s
```