### PR TITLE
Обработка ошибок AmoCRM в теле ответа

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,16 @@
 {
-    "name": "dotzero/amocrm",
-    "description": "Удобный и быстрый клиент для работы с API amoCRM",
+    "name": "shadoll/amocrm",
+    "description": "Удобный и быстрый клиент для работы с API amoCRM - shadoll fork",
     "license": "MIT",
     "keywords": ["amocrm", "crm", "api"],
     "authors": [
         {
             "name": "dotzero",
             "email": "mail@dotzero.ru"
+        },
+        {
+            "name": "sHa",
+            "email": "sha@shadoll.com"
         }
     ],
     "require": {

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Models\Cache;
+
 /**
  * Class Account
  *
@@ -32,7 +34,11 @@ class Account extends AbstractModel
      */
     public function apiCurrent($short = false, $parameters = [])
     {
-        $result = $this->getRequest('/private/api/v2/json/accounts/current', $parameters);
+        $result = (new Cache)->getCache('accounts_current');
+        if(!$result){
+            $result = $this->getRequest('/private/api/v2/json/accounts/current', $parameters);
+            (new Cache)->setCache('accounts_current',$result);
+        }
 
         return $short ? $this->getShorted($result['account']) : $result['account'];
     }

--- a/src/Models/Cache.php
+++ b/src/Models/Cache.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace AmoCRM\Models;
+
+/**
+ * Class Cache
+ */
+
+class Cache
+{
+    private $cache_path = '';
+    private $expire = null;
+
+    function __construct()
+    {
+        $this->cache_path = defined('CACHE_DIR')?CACHE_DIR:sys_get_temp_dir();
+        $this->expire = defined('CACHE_EXPIRE')?CACHE_EXPIRE:'3600';
+    }
+
+    function cache(){
+
+    }
+
+    function setCache($name,$data){
+        $this->writeFile($name,json_encode($data));
+        return $data;
+    }
+
+    function getCache($name, $expire=null){
+        if(!is_null($expire)){
+            $this->expire = $expire;
+        }
+
+        $cached = $this->readFile($name);
+
+        if($cached !== false){
+            $data = json_decode($cached, true);
+            $cache_time = $data['server_time'];
+            $now_time = time();
+            if($now_time >= $cache_time && $now_time <= ($cache_time + $this->expire)){
+                return $data;
+            }
+        }
+        return false;
+    }
+
+    function writeFile($name, $content){
+        try {
+            if(!is_dir($this->cache_path)) {
+                mkdir($this->cache_path);
+            }
+            return file_put_contents($this->cache_path."/".$name,$content);
+        } catch (Exception $e) {
+            // Handle exception
+            return false;
+        }
+    }
+
+    function readFile($name){
+        try {
+            $content = file_get_contents($this->cache_path."/".$name, false);
+            if ($content === false) {
+                // Handle the error
+            } else {
+                return $content;
+            }
+        } catch (Exception $e) {
+            // Handle exception
+            return false;
+        }
+    }
+}

--- a/src/Models/Catalog.php
+++ b/src/Models/Catalog.php
@@ -76,7 +76,12 @@ class Catalog extends AbstractModel
 
         if (isset($response['catalogs']['add']['catalogs'])) {
             $result = array_map(function ($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['catalogs']['add']['catalogs']);
         } else {
             return [];

--- a/src/Models/Catalog.php
+++ b/src/Models/Catalog.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
+
 /**
  * Class Catalog
  *

--- a/src/Models/CatalogElement.php
+++ b/src/Models/CatalogElement.php
@@ -72,7 +72,12 @@ class CatalogElement extends AbstractModel
 
         if (isset($response['catalog_elements']['add']['catalog_elements'])) {
             $result = array_map(function ($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['catalog_elements']['add']['catalog_elements']);
         } else {
             return [];

--- a/src/Models/CatalogElement.php
+++ b/src/Models/CatalogElement.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
+
 /**
  * Class CatalogElement
  *

--- a/src/Models/Company.php
+++ b/src/Models/Company.php
@@ -86,7 +86,12 @@ class Company extends AbstractModel
 
         if (isset($response['contacts']['add'])) {
             $result = array_map(function($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['contacts']['add']);
         } else {
             return [];

--- a/src/Models/Company.php
+++ b/src/Models/Company.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetTags;
 use AmoCRM\Models\Traits\SetDateCreate;
 use AmoCRM\Models\Traits\SetLastModified;

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -90,7 +90,12 @@ class Contact extends AbstractModel
 
         if (isset($response['contacts']['add'])) {
             $result = array_map(function ($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['contacts']['add']);
         } else {
             return [];

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetNote;
 use AmoCRM\Models\Traits\SetTags;
 use AmoCRM\Models\Traits\SetDateCreate;

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -98,7 +98,12 @@ class CustomField extends AbstractModel
 
         if (isset($response['fields']['add'])) {
             $result = array_map(function ($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['fields']['add']);
         } else {
             return [];

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
+
 /**
  * Class CustomField
  *

--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetTags;
 use AmoCRM\Models\Traits\SetNextDate;
 

--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -81,7 +81,12 @@ class Customer extends AbstractModel
 
         if (isset($response['customers']['add'])) {
             $result = array_map(function ($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['customers']['add']['customers']);
         } else {
             return [];

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetNote;
 use AmoCRM\Models\Traits\SetTags;
 use AmoCRM\Models\Traits\SetDateCreate;

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -91,7 +91,12 @@ class Lead extends AbstractModel
 
         if (isset($response['leads']['add'])) {
             $result = array_map(function($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['leads']['add']);
         } else {
             return [];

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetDateCreate;
 use AmoCRM\Models\Traits\SetLastModified;
 

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -141,7 +141,12 @@ class Note extends AbstractModel
 
         if (isset($response['notes']['add'])) {
             $result = array_map(function($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['notes']['add']);
         } else {
             return [];

--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetDateCreate;
 use AmoCRM\Models\Traits\SetLastModified;
 

--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -112,7 +112,12 @@ class Task extends AbstractModel
 
         if (isset($response['tasks']['add'])) {
             $result = array_map(function($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['tasks']['add']);
         } else {
             return [];

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -2,6 +2,7 @@
 
 namespace AmoCRM\Models;
 
+use AmoCRM\Exception;
 use AmoCRM\Models\Traits\SetDate;
 use AmoCRM\Models\Traits\SetNextDate;
 

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -80,7 +80,12 @@ class Transaction extends AbstractModel
 
         if (isset($response['transactions']['add']['transactions'])) {
             $result = array_map(function ($item) {
-                return $item['id'];
+				if(!empty($item['id']))
+					return $item['id'];
+				elseif(!empty($item['error']))
+					throw new Exception($item['error'],filter_var(mb_strstr($item['error'],".",true), FILTER_SANITIZE_NUMBER_INT));
+				else
+					return [];
             }, $response['transactions']['add']['transactions']);
         } else {
             return [];

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -320,6 +320,6 @@ class Request
         if(!is_dir($log_dir)) {
             mkdir($log_dir);
         }
-        file_put_contents($log_dir."/amo_requests.log",microtime(true)." | ".$timestamp." ".strtoupper($entity)." ".$value. PHP_EOL);
+        file_put_contents($log_dir."/amo_requests.log",microtime(true)." | ".$timestamp." ".strtoupper($entity)." ".$value. PHP_EOL, FILE_APPEND | LOCK_EX);
     }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -320,6 +320,6 @@ class Request
         if(!is_dir($log_dir)) {
             mkdir($log_dir);
         }
-        file_put_contents($log_dir."/amo_requests.log"," [".$timestamp."] ".microtime(true)." | ".strtoupper($entity)." ".$value. PHP_EOL, FILE_APPEND | LOCK_EX);
+        file_put_contents($log_dir."/amo_requests.log","[".$timestamp."] ".microtime(true)." | ".strtoupper($entity)." ".$value. PHP_EOL, FILE_APPEND | LOCK_EX);
     }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -315,11 +315,11 @@ class Request
     }
 
     protected function logRequest($value, $entity=""){
-        $timestamp = gmdate("Y.m.d H:i:s", time());
+        $timestamp = gmdate("Y-m-d H:i:s", time());
         $log_dir = defined('LOG_DIR')?LOG_DIR:sys_get_temp_dir();
         if(!is_dir($log_dir)) {
             mkdir($log_dir);
         }
-        file_put_contents($log_dir."/amo_requests.log",microtime(true)." | ".$timestamp." ".strtoupper($entity)." ".$value. PHP_EOL, FILE_APPEND | LOCK_EX);
+        file_put_contents($log_dir."/amo_requests.log"," [".$timestamp."] ".microtime(true)." | ".strtoupper($entity)." ".$value. PHP_EOL, FILE_APPEND | LOCK_EX);
     }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -204,6 +204,8 @@ class Request
         $headers = $this->prepareHeaders($modified);
         $endpoint = $this->prepareEndpoint($url);
 
+        $this->logRequest($endpoint, 'REQUEST');
+
         $this->printDebug('url', $endpoint);
         $this->printDebug('headers', $headers);
 
@@ -310,5 +312,14 @@ class Request
         }
 
         return $line;
+    }
+
+    protected function logRequest($value, $entity=""){
+        $timestamp = gmdate("Y.m.d H:i:s", time());
+        $log_dir = defined('LOG_DIR')?LOG_DIR:sys_get_temp_dir();
+        if(!is_dir($log_dir)) {
+            mkdir($log_dir);
+        }
+        file_put_contents($log_dir."/amo_requests.log",microtime(true)." | ".$timestamp." ".strtoupper($entity)." ".$value. PHP_EOL);
     }
 }


### PR DESCRIPTION
Добавлена обработка ошибок в теле ответа

Иногда AmoCRM отдает код ошибки прямо в теле response
Пример:
Если добавлять контакт без имени, то прилетает ответ в таком виде
$response['contacts']['add']['error'=>"Код ошибки 205. В случае повторного возникновения ошибки, обращайтесь в нашу техническую поддержку - support@amocrm.ru"]

