### PR TITLE
Возможность добавлять теги по их ID

### DIFF
--- a/src/Models/Traits/SetTags.php
+++ b/src/Models/Traits/SetTags.php
@@ -16,7 +16,12 @@ trait SetTags
             $value = [$value];
         }
 
-        $this->values['tags'] = implode(',', $value);
+        $types = array_unique(array_map('gettype', array_values($value)));
+        if (count($types) == 1 && $types[0] == 'integer') {
+            $this->values['tags'] = $value;
+        } else {
+            $this->values['tags'] = implode(',', $value);
+        }
 
         return $this;
     }


### PR DESCRIPTION
В новой документации [сказано](https://www.amocrm.ru/developers/content/api/leads) что можно добавлять существующие теги путем передачи массива с идентификаторами. Сейчас это выполнить невозможно т.к. все что поступает, воспринимается как название тега, таким же образом и передается.

Теперь метод **setTags()** проверяет тип данных, если **все** передаваемые значения являются типом integer, передает их массивом, во всех других случаях метод работает как раньше.