### PR TITLE
Change parameters for testParseResponseEmpty

### DIFF
--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -145,7 +145,12 @@ class RequestTest extends TestCase
 
     public function testParseResponseEmpty()
     {
-        $actual = $this->invokeMethod($this->request, 'parseResponse', [null, null]);
+        $response = '';
+        $info = [
+            'http_code' => 200
+        ];
+
+        $actual = $this->invokeMethod($this->request, 'parseResponse', [$response, $info]);
         $this->assertFalse($actual);
     }
 


### PR DESCRIPTION
В ветке master при запуске тестов:
```
vendor/bin/phpunit                                                                                                                                                                                                                  
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

...............................................................  63 / 275 ( 22%)
............................................................... 126 / 275 ( 45%)
............................................................... 189 / 275 ( 68%)
............................................................... 252 / 275 ( 91%)
..E....................                                         275 / 275 (100%)

Time: 70 ms, Memory: 8.00MB

There was 1 error:

1) RequestTest::testParseResponseEmpty
Trying to access array offset on value of type null

/Volumes/develop/libraries/amocrm-php/src/Request/Request.php:266
/Volumes/develop/libraries/amocrm-php/tests/TestCase.php:35
/Volumes/develop/libraries/amocrm-php/tests/Request/RequestTest.php:148

ERRORS!
Tests: 275, Assertions: 728, Errors: 1.
```
Были изменены параметры для AmoCRM\Request\Request::parseResponse